### PR TITLE
feat: add test tools and default interactive mode for CLIs

### DIFF
--- a/mcp_server.config.js
+++ b/mcp_server.config.js
@@ -59,6 +59,59 @@ export default {
         };
       },
     },
+    {
+      name: 'long-time-run',
+      description: 'Wait for specified seconds before returning (for testing timeouts)',
+      parameters: {
+        timeSecs: z.number().describe('Time to wait in seconds'),
+      },
+      handler: async (args, extra) => {
+        const { timeSecs } = args;
+        
+        // Wait for the specified time
+        await new Promise(resolve => setTimeout(resolve, timeSecs * 1000));
+        
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Waited for ${timeSecs} seconds`,
+            },
+          ],
+        };
+      },
+    },
+    {
+      name: 'long-response',
+      description: 'Return a response of specified length in bytes (for testing different response sizes)',
+      parameters: {
+        length: z.number().describe('Response length in bytes'),
+      },
+      handler: async (args, extra) => {
+        const { length } = args;
+        
+        // Generate a response of the specified length
+        // Using a pattern to make it somewhat readable
+        const pattern = 'abcdefghijklmnopqrstuvwxyz0123456789';
+        let response = '';
+        
+        while (response.length < length) {
+          response += pattern;
+        }
+        
+        // Trim to exact length
+        response = response.substring(0, length);
+        
+        return {
+          content: [
+            {
+              type: 'text',
+              text: response,
+            },
+          ],
+        };
+      },
+    },
   ],
 
   resources: [

--- a/src/cli/server.ts
+++ b/src/cli/server.ts
@@ -25,10 +25,9 @@ program
 
 // Server options
 program
-  .requiredOption('-t, --transport <type>', 'Transport type (http/sse/stdio)')
+  .option('-t, --transport <type>', 'Transport type (http/sse/stdio)', 'sse')
   .option('-p, --port <port>', 'Port for HTTP server (http/sse transport)', '3000')
   .option('-n, --name <name>', 'Server name', 'mcp-test-server')
-  .option('-i, --interactive', 'Enable interactive mode')
   .option('-v, --verbose', 'Enable verbose message logging', false)
   .option(
     '--ping-interval <ms>',
@@ -46,7 +45,7 @@ const serverOptions: CLIServerOptions = {
   description: 'MCP server CLI with interactive commands',
   transport: cliOptions.transport,
   port: parseInt(cliOptions.port),
-  interactive: cliOptions.interactive,
+  interactive: true,
   verbose: cliOptions.verbose,
   pingInterval: cliOptions.pingInterval,
 };


### PR DESCRIPTION
## Summary
- Added two new test tools to the server for testing edge cases
- Updated CLI behavior to default to interactive mode when no specific actions are requested
- Fixed TypeScript import warning

## Test Tools Added

### 1. `long-time-run`
- **Purpose**: Test timeout scenarios
- **Parameter**: `timeSecs` (number) - Time to wait in seconds
- **Usage**: Waits for the specified duration before returning

### 2. `long-response`
- **Purpose**: Test different response sizes
- **Parameter**: `length` (number) - Response length in bytes
- **Usage**: Returns a response of exactly the specified length

## CLI Changes

### Client CLI
- Now defaults to interactive mode (`-i`) when no action flags are specified
- Action flags include: `--list-tools`, `--call-tool`, `--list-resources`, `--read-resource`, `--list-prompts`, `--get-prompt`
- Maintains backward compatibility with existing commands

### Server CLI
- Now defaults to interactive mode when only the transport flag is provided
- Interactive mode is always enabled by default
- Removed the need for explicit `-i` flag

## Test Plan
- [ ] Test `long-time-run` tool with various timeout values
- [ ] Test `long-response` tool with different response sizes
- [ ] Verify client CLI defaults to interactive mode when run without flags
- [ ] Verify server CLI defaults to interactive mode with only transport specified
- [ ] Confirm all existing CLI commands still work as expected

🤖 Generated with [Claude Code](https://claude.ai/code)